### PR TITLE
Update upgrade.sh

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -85,10 +85,6 @@ if [ -z "$BASH" ]; then
     abort "请用 bash 执行本脚本, 请参考最新的官方技术文档 https://waf-ce.chaitin.cn/"
 fi
 
-if [ ! -t 0 ]; then
-    abort "STDIN 不是标准的输入设备, 请参考最新的官方技术文档 https://waf-ce.chaitin.cn/"
-fi
-
 if [ "$#" -ne "0" ]; then
     abort "当前脚本无需任何参数, 请参考最新的官方技术文档 https://waf-ce.chaitin.cn/"
 fi


### PR DESCRIPTION
自己碰到的情况，我的 Ubuntu Server 20.04 LTS 64bit 服务器更新雷池提示“STDIN 不是标准的输入设备”
将该判断条件删掉，成功更新雷池WAF
想更新一下，这样更加能覆盖全环境，也欢迎各位师傅与我交流~