### PR TITLE
feat(custom-rule): add HTTP method as filterable field

### DIFF
--- a/management/webserver/model/policyrule.go
+++ b/management/webserver/model/policyrule.go
@@ -17,9 +17,10 @@ type PolicyRulePattern struct {
 }
 
 const (
-	KeySrcIP = "src_ip"
-	KeyURI   = "uri"
-	KeyHost  = "host"
+	KeySrcIP  = "src_ip"
+	KeyURI    = "uri"
+	KeyHost   = "host"
+	KeyMethod = "method" // HTTP request method (GET/POST/...)
 
 	OpEq     = "eq"     // 完全相等
 	OpMatch  = "match"  // 模糊匹配

--- a/management/webserver/pkg/fvm/generator.go
+++ b/management/webserver/pkg/fvm/generator.go
@@ -177,6 +177,8 @@ func PolicyRuleTable(db *gorm.DB) (prFSL string, err error) {
 				key = "@uri_decoded::STRING"
 			case model.KeyHost:
 				key = "http.host"
+			case model.KeyMethod:
+				key = "http.method"
 			default:
 				return "", errors.New("wrong Key")
 			}


### PR DESCRIPTION
Custom Rules only supported src_ip/uri/host as match keys. Add 'method' key, mapped to the engine's existing http.method variable (populated by blazehttp parser), so rules can match on GET/POST/etc.

No engine changes required, http.method is already extracted by the request parser alongside http.host.