### PR TITLE
Do not disable TLS certificate verification in the installer (fixes #1304)

### DIFF
--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -497,8 +497,6 @@ def init_global_config():
     global REQUEST_CTX, LANG, DOMAIN, PRODUCT, DEBUG
 
     REQUEST_CTX = ssl.create_default_context()
-    REQUEST_CTX.check_hostname = False
-    REQUEST_CTX.verify_mode = ssl.CERT_NONE
 
     parser = argparse.ArgumentParser(
         prog='installer-management',


### PR DESCRIPTION
Draft PR for #1304.

## What this changes

`scripts/manage.py` disabled TLS certificate verification for all installer downloads:

```python
REQUEST_CTX = ssl.create_default_context()
REQUEST_CTX.check_hostname = False      # removed
REQUEST_CTX.verify_mode = ssl.CERT_NONE # removed
```

`ssl.create_default_context()` already validates the CA chain and hostname by default, so this PR just removes the two override lines. That restores server authentication for the `get-docker.sh`, `compose.yaml`, and `version.json` downloads — closing the MITM path, given `get-docker.sh` is executed with `bash` (manage.py:744).

Two-line deletion, single concern. See #1304 for the full write-up.

## Note / open question

I removed the override globally on the assumption that `waf-ce.chaitin.cn` / `waf.chaitin.com` serve valid certificates. If verification was disabled to work around a specific host or an offline/self-signed setup, a narrower approach (a per-host exception, or verifying a published checksum of `get-docker.sh` before running it) would keep the other downloads authenticated. Happy to adjust to whatever fits your deployment — hence opening this as a draft.

---

*Disclosure: I used an AI tool to help find this and prepare the change; I verified it against `scripts/manage.py` myself and take responsibility for it.*
