### PR TITLE
fix: restore TLS certificate verification in installer

### DIFF
--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -497,8 +497,6 @@ def init_global_config():
     global REQUEST_CTX, LANG, DOMAIN, PRODUCT, DEBUG
 
     REQUEST_CTX = ssl.create_default_context()
-    REQUEST_CTX.check_hostname = False
-    REQUEST_CTX.verify_mode = ssl.CERT_NONE
 
     parser = argparse.ArgumentParser(
         prog='installer-management',


### PR DESCRIPTION
Remove the check_hostname/verify_mode overrides in init_global_config() so ssl.create_default_context() keeps its secure defaults. Without verification, a MITM attacker could substitute content for downloads such as get-docker.sh, which is then executed with bash as root.